### PR TITLE
Delete metadata before PUT request

### DIFF
--- a/python_examples/example_03_set_video_input_description.py
+++ b/python_examples/example_03_set_video_input_description.py
@@ -86,6 +86,9 @@ def main():
     video_input["description"] = ("SDI in 1 - Last description update at " +
                                   current_time)
 
+    # Strip metadata before reuse. Reduces following request overhead.
+    del video_input["_links"]
+
     # Use a PUT request to update the video input description on your unit.
     # If the PUT request is successful it returns the updated resource.
     # Through storing this response in a variable an additional GET request

--- a/python_examples/example_05_turn_recording_on_and_off.py
+++ b/python_examples/example_05_turn_recording_on_and_off.py
@@ -81,6 +81,9 @@ def set_recording(recording_value):
 
     recording["active"] = recording_value
 
+    # Strip metadata before reuse. Reduces following request overhead.
+    del recording["_links"]
+
     # Start or stop actual recording session, depending on "recording_value".
     response = direkt.put(RECORDING_SETTINGS_URL, auth=AUTHENTICATION,
                           json=recording)
@@ -150,6 +153,9 @@ def main():
         # Update the activation status for the chosen recording format in your
         # dictionary (other formats analogously).
         encoder["recording"][recording_format]["active"] = True
+
+        # Strip metadata before reuse. Reduces following request overhead.
+        del encoder["_links"]
 
         # Use a PUT request to activate the recording format. If the PUT
         # request is successful it returns the updated resource. Through


### PR DESCRIPTION
Delete metadata from the previous GET request to reduce the data amount
in the following PUT request. This is a best practice that reduces the
amount of data sent to the server.